### PR TITLE
Fix Context.synchronize in case it is not yet initialized

### DIFF
--- a/src/cuda4py/_py.py
+++ b/src/cuda4py/_py.py
@@ -700,6 +700,8 @@ class Context(CU):
         self.device = device
 
     def synchronize(self):
+        if self.handle is None:
+            return
         err = self._lib.cuCtxSynchronize()
         if err:
             raise CU.error("cuCtxSynchronize", err)


### PR DESCRIPTION
Another Python3 breaker during the destruction
